### PR TITLE
Support multiple languages subtitles

### DIFF
--- a/Command Line/Program.cs
+++ b/Command Line/Program.cs
@@ -4,7 +4,7 @@ namespace CommandLine
 {
     public class Program
     {
-        public const string DefaultLanguage = "eng";
+        public const string DefaultLanguage = "English";
         public static void Main(string[] args)
         {
             var lang = DefaultLanguage;

--- a/lib/Renamer.cs
+++ b/lib/Renamer.cs
@@ -1,4 +1,6 @@
-﻿namespace lib;
+﻿using System.Globalization;
+
+namespace lib;
 
 
 public class Renamer
@@ -109,6 +111,12 @@ internal static class Utils
 {
     public static void RenameFiles(FileInfo[] files, DirectoryInfo outputDir, string subtitleName, string language, int priority)
     {
+        var languageCode = language;
+        if (languageCode.Length > 3)//If 3 chars or less, we assume the language provided was already a valid language code
+        {
+            languageCode = GetISOCodeMatchingLanguage(language);
+        }
+
         var subs = GetFilesMatchingLanguage(files, language);
         if (subs.Count == 0) return;
 
@@ -118,7 +126,7 @@ internal static class Utils
         subs.Sort((s1, s2) => s2.Length.CompareTo(s1.Length));
 
         var subFile = subs[priority];
-        var newPath = Path.Combine($@"{outputDir.FullName}", $@"{subtitleName}.{language}{subFile.Extension}");
+        var newPath = Path.Combine($@"{outputDir.FullName}", $@"{subtitleName}.{languageCode}{subFile.Extension}");
         subFile.CopyTo(newPath, true);
     }
 
@@ -132,6 +140,18 @@ internal static class Utils
         }
 
         return subs;
+    }
+    public static string GetISOCodeMatchingLanguage(string languageName)
+    {
+        //Compile a dict to access a culture by its english name
+        var cultureInfosDict = CultureInfo.GetCultures(CultureTypes.AllCultures)
+                    .ToLookup(x => x.EnglishName.ToLowerInvariant());
+
+        var requestedCulture = cultureInfosDict[languageName].FirstOrDefault();
+        var languageCode = requestedCulture?.ThreeLetterISOLanguageName;
+
+        //If languageCode was not acquired, return the provided language.
+        return languageCode ?? languageName;
     }
 
 }

--- a/lib/Renamer.cs
+++ b/lib/Renamer.cs
@@ -118,7 +118,7 @@ internal static class Utils
         subs.Sort((s1, s2) => s2.Length.CompareTo(s1.Length));
 
         var subFile = subs[priority];
-        var newPath = Path.Combine($@"{outputDir.FullName}", $@"{subtitleName}{subFile.Extension}");
+        var newPath = Path.Combine($@"{outputDir.FullName}", $@"{subtitleName}.{language}{subFile.Extension}");
         subFile.CopyTo(newPath, true);
     }
 


### PR DESCRIPTION
Appends the subtitle ISO 3 letter language code at in the subtitle name, as follow `subtitle.lang.srt`
The language code is either the user provided 3 char string if it, or a query is made to get the 3 letter code from the english language name 

(e.g. setting `-l "Chinese"` names the file `subtitle.zho.srt`)

This also allows to run the script sequentially with multiple languages to keep them before deleting the rest.

Does that seem like a good addition to you, or would it be better left optional ?